### PR TITLE
Désactivation du thème sombre

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,7 @@
 {% load static dsfr_tags wagtailsettings_tags %}
 {% get_settings %}
 <!doctype html>
-<html lang="fr" data-fr-scheme="system" {% if SITE_CONFIG.mourning %}data-fr-mourning{% endif %}>
+<html lang="fr" {% if SITE_CONFIG.mourning %}data-fr-mourning{% endif %}>
 
 <head>
   <meta charset="utf-8" />


### PR DESCRIPTION
## Quoi ?

Désactivation du thème sombre

## Pourquoi ?

Les images et le contenu gérés par le CMS ne rendent pas toujours bien dans le thème sombre.