### PR TITLE
Mise à jour de la version de Python en 3.11 en local + suppression de la dépendance Airtable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.11
 
 EXPOSE 8000
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,3 @@ wagtailmenus==3.1.3
 boto3==1.26.133
 django-storages==1.13.2
 wagtail-airtable==0.6.0
-airtable==0.4.8


### PR DESCRIPTION
Les environnements de staging et de prod sont en python 3.11, l'environnement local doit donc être dans la même version.
En python 3.11, le package "airtable" est en conflit avec "airtable-python-wrapper" utilisé par "wagtail-airtable". Le paquet est supprimé puisque le code semble aussi fonctionner avec le wrapper.