### PR TITLE
fix(Syncho): Augmentation de la longueur de chaîne pour la durée

### DIFF
--- a/formations/serializers.py
+++ b/formations/serializers.py
@@ -64,7 +64,7 @@ class FormationPageSerializer(AirtableSerializer):
     kind = LowerCharSerializer(max_length=20, required=True)
     short_description = serializers.CharField(required=False)
     knowledge_at_the_end = serializers.CharField(required=False)
-    duration = serializers.CharField(max_length=100, required=False)
+    duration = serializers.CharField(max_length=255, required=False)
     registration_link = serializers.URLField(required=False)
     target_audience = TargetAudienceSerializer(required=False, many=True)
     themes = ThemeSerializer(required=False, many=True)


### PR DESCRIPTION
## 🎯 Objectif

Corriger les échecs de synchro lié à la longueur du champs "Durée"

## 🔍 Implémentation

Augmentation de la longueur de la chaîne au niveau du sérialiseur à 255 (comme sur le modèle)
